### PR TITLE
feat: add apm.yml for platform-mode configuration and dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ override.tf.json
 # Ignore CLI configuration files
 .terraformrc
 terraform.rc
+copilot-logs
+.apm/compiled

--- a/apm.yml
+++ b/apm.yml
@@ -1,0 +1,11 @@
+name: platform-mode
+version: 1.0.0
+description: Platform Mode is an advanced, spec-driven development toolkit that transforms how platform engineering teams build and operate Internal Developer Platforms (IDPs).
+author: raykao
+
+dependencies:
+  mcp:
+    - azure/azure-mcp
+
+scripts:
+  discovery-codex: "RUST_LOG=debug codex --skip-git-repo-check discovery.prompt.md"


### PR DESCRIPTION
This pull request introduces a new `apm.yml` file to the project. 

It allows platform-mode to become an APM module that others can install by adding it to their APM dependencies file:

```
name: my-project
version: 1.0.0
description: This project uses Platform-mode
author: danielmeppiel

dependencies:
  apm:
    - DevExpGbb/platform-mode

scripts:
  discovery-codex: "RUST_LOG=debug codex --skip-git-repo-check discovery.prompt.md"
  # Continue exposing any scripts from the package
```

And then, once [spec-kit PR is merged](https://github.com/github/spec-kit/pull/271)

`specify apm install`
`specify apm run discovery-codex`

<img width="1048" height="521" alt="image" src="https://github.com/user-attachments/assets/f43745a8-5efb-40fe-b8f5-f73331ecb416" />
